### PR TITLE
feat(skills): add library usage rules and javadocs MCP config (#5)

### DIFF
--- a/mcp/mcp.json
+++ b/mcp/mcp.json
@@ -1,1 +1,7 @@
-{}
+{
+  "mcpServers": {
+    "javadocs": {
+      "url": "https://mcp.javadocs.dev/"
+    }
+  }
+}

--- a/skills/general-programming/SKILL.md
+++ b/skills/general-programming/SKILL.md
@@ -20,6 +20,7 @@ These principles apply to all programming tasks regardless of language or framew
 ### Anti-patterns (Never Do This)
 
 **Empty catch blocks:**
+
 ```java
 // BAD - exception is silently lost
 try {
@@ -32,6 +33,7 @@ try {
 ### Correct Approaches
 
 **Rethrow when you cannot handle it:**
+
 ```java
 // GOOD - rethrow to let caller handle
 try {
@@ -42,6 +44,7 @@ try {
 ```
 
 **Log when you need to continue:**
+
 ```java
 // GOOD - log with context before continuing
 try {
@@ -70,12 +73,14 @@ try {
 Before considering any task complete, run the relevant tests. See the `testing` skill for detailed guidance on test philosophy and patterns.
 
 **Key principles:**
+
 - Prefer **sociable tests** (real collaborators) over **solitary tests** (mocks)
 - Prefer **narrow integration tests** (test one integration point) over broad end-to-end tests
 - Test observable behavior through public APIs, not implementation details
 - Use stubs/fakes for external services; avoid mocks unless necessary
 
 **Coverage targets:**
+
 - Maintain high coverage (90%+)
 - Trivial code (getters/setters) should be exercised by other tests, not explicitly tested
 - If trivial code isn't covered, question whether it's needed (libraries may be an exception)
@@ -85,12 +90,14 @@ Before considering any task complete, run the relevant tests. See the `testing` 
 Prefer immutable objects and data structures where immutability doesn't reduce comprehension.
 
 **Benefits:**
+
 - Thread safety without synchronization
 - Predictable behavior - no surprise state changes
 - Easier to reason about code
 - Fewer defensive copies needed
 
 **Examples:**
+
 ```java
 // GOOD - immutable record
 public record Person(String name, int age) {}
@@ -106,6 +113,7 @@ var config = Config.builder()
 ```
 
 **Avoid setters** - Instead of anemic data objects with getters/setters, prefer domain-driven design with rich behavior:
+
 ```java
 // BAD - anemic object with setter
 person.setStatus("APPROVED");
@@ -115,6 +123,7 @@ person.approve();
 ```
 
 **When mutability is acceptable:**
+
 - Performance-critical code where immutability causes measurable overhead
 - Accumulators/builders during object construction
 - Cases where it significantly reduces comprehension
@@ -124,23 +133,28 @@ person.approve();
 Design code that follows SOLID principles with a focus on polymorphic behavior:
 
 ### Single Responsibility
+
 - Each unit (class, function, module) has one reason to change
 - Let your domain language define responsibilities
 - Build units around single responsibilities derived from the domain
 
 ### Open/Closed Principle
+
 - Open for extension, closed for modification
 - Use polymorphism to add behavior without changing existing code
 
 ### Liskov Substitution
+
 - Subtypes must be substitutable for their base types
 - Polymorphic behavior should be predictable
 
 ### Interface Segregation
+
 - Prefer small, focused interfaces over large, general ones
 - Clients shouldn't depend on methods they don't use
 
 ### Dependency Inversion
+
 - Depend on abstractions, not concrete implementations
 - This enables the polymorphic behavior that makes systems flexible
 
@@ -149,6 +163,7 @@ Design code that follows SOLID principles with a focus on polymorphic behavior:
 **Encapsulate behavior so it's polymorphic** - let the unit decide how to act rather than orchestrating externally.
 
 **Polymorphism takes many forms:**
+
 - Traditional inheritance and interfaces
 - Lambdas and functional programming (passing behavior as data)
 - Strategy patterns and dependency injection
@@ -194,6 +209,7 @@ If you follow these principles, your code will naturally be composable, clear, a
 ### Git/Repository Assumptions (Dangerous)
 
 **Do not assume:**
+
 - Your local `develop` (or default branch) is current with `origin`
 - Files haven't changed since you last read them
 - Branches you created are still valid (PRs may have been merged/closed)
@@ -202,6 +218,7 @@ If you follow these principles, your code will naturally be composable, clear, a
 ### Workspace Assumptions (Dangerous)
 
 **Do not assume exclusive access to:**
+
 - The filesystem (other processes/agents may modify files)
 - Environment variables (may change between invocations)
 - Network ports (may be in use by other services)
@@ -210,6 +227,7 @@ If you follow these principles, your code will naturally be composable, clear, a
 ### Correct Approaches
 
 **Verify git state at session start:**
+
 ```bash
 # Always check if local HEAD is behind origin
 git fetch origin
@@ -220,6 +238,7 @@ git pull origin develop
 ```
 
 **Don't assume file state persists:**
+
 ```java
 // BAD - assumes file hasn't changed since last read
 private Config cachedConfig;  // May be stale
@@ -231,6 +250,7 @@ public Config getConfig() {
 ```
 
 **Explicitly verify external state:**
+
 ```bash
 # Check if port is available before using
 if ! lsof -i :8080 > /dev/null 2>&1; then
@@ -241,6 +261,10 @@ fi
 ```
 
 **When uncertain, verify** rather than assuming state is as you left it.
+
+## Rule 6: Use Libraries When Available
+
+Before implementing new functionality, check if it's already provided by standard libraries or existing dependencies. **Prefer existing code over writing your own**, even for seemingly "trivial" functions.
 
 ---
 

--- a/skills/iterative-development/SKILL.md
+++ b/skills/iterative-development/SKILL.md
@@ -1,0 +1,316 @@
+---
+name: iterative-development
+description: |
+  Apply iterative development principles combining Craig Larman's RUP process
+  and Eric Evans' whirlpool design. Use when starting new features, refining
+  existing code, or when the domain model needs to evolve. Guides short
+  timeboxed iterations, risk-driven development, and continuous refactoring
+  toward deeper insight.
+---
+
+<!--
+SPDX-FileCopyrightText: Copyright © 2026 Caleb Cushing
+
+SPDX-License-Identifier: CC-BY-NC-SA-4.0
+-->
+
+# Iterative Development
+
+Guidance for iterative development combining Craig Larman's RUP approach with
+Eric Evans' whirlpool design from Domain-Driven Design.
+
+## Core Principles
+
+### 1. Short Timeboxed Iterations
+
+Work in iterations of 2-6 weeks maximum. Each iteration must produce:
+
+- **Executable, tested code** - Not just design documents
+- **Vertical slices** - Working features end-to-end
+- **Demonstrable progress** - Can be shown to stakeholders
+
+> "The code is the design." - The best way to validate architecture is working
+> software.
+
+### 2. Risk-Driven Development
+
+Address highest-risk items early:
+
+- **Technical risks** - Unknown technologies, integrations, performance
+- **Domain complexity** - Core domain concepts that are poorly understood
+- **Requirements uncertainty** - Areas where business needs are unclear
+
+Each iteration should reduce overall project risk.
+
+### 3. Start Simple, Refine Through Whirlpool
+
+Follow Eric Evans' whirlpool model - start with a simple model and refine it
+through iterations:
+
+```
+        Deeper
+        Insight
+           ↑
+   ┌───────┴───────┐
+   │   Refactor    │
+   │   Toward      │
+   │   Deeper      │
+   │   Insight     │
+   └───────┬───────┘
+           ↓
+   ┌───────┴───────┐
+   │ Distill       │
+   │ Ubiquitous    │
+   │ Language      │
+   └───────┬───────┘
+           ↓
+   ┌───────┴───────┐
+   │ Challenge     │
+   │ Assumptions   │
+   └───────┬───────┘
+           ↓
+   ┌───────┴───────┐
+   │ Initial       │
+   │ Model         │
+   └───────────────┘
+```
+
+### 4. Refactoring Toward Deeper Insight
+
+As understanding grows, refactor the model:
+
+- **Ubiquitous language** evolves with the model
+- **Bounded contexts** emerge and clarify
+- **Aggregates** are refined as invariants are understood
+- **Domain events** are discovered through scenario analysis
+
+### 5. Requirements Emerge Through Feedback
+
+Requirements are not fully knowable upfront:
+
+- **Prototypes inform requirements** - Build to learn
+- **User feedback drives priorities** - Adapt based on what works
+- **Deferred commitment** - Make reversible decisions early
+
+## Iteration Structure
+
+### Start of Iteration
+
+1. **Select goals** based on:
+   - Risk reduction
+   - Business value
+   - Learning opportunities
+
+2. **Plan minimally**:
+   - What scenarios will work?
+   - What experiments need to run?
+   - What's the "walking skeleton"?
+
+### During Iteration
+
+1. **Build working software**:
+   - Test-driven development
+   - Vertical slices
+   - Continuous integration
+
+2. **Refactor continuously**:
+   - Rename as language evolves
+   - Extract concepts as they emerge
+   - Simplify as understanding grows
+
+3. **Capture learning**:
+   - Update ubiquitous language
+   - Document new domain insights
+   - Note emerging bounded contexts
+
+### End of Iteration
+
+1. **Demonstrate working software**
+2. **Gather feedback** from stakeholders
+3. **Reflect on what was learned**:
+   - What did we get wrong?
+   - What simplified?
+   - What became more complex?
+4. **Adjust priorities** for next iteration
+
+## Anti-Patterns
+
+### Big Design Up Front
+
+❌ Trying to design the complete domain model before writing code.
+
+> The model will be wrong. Start simple and let it evolve.
+
+### Analysis Paralysis
+
+❌ Endless modeling sessions without working code.
+
+> Model in code, not on whiteboards. Working software reveals flaws that
+> diagrams hide.
+
+### Premature Abstraction
+
+❌ Extracting frameworks or abstractions before the pattern is proven.
+
+> Wait for three instances before generalizing. Let the design emerge.
+
+### Ignoring the Whirlpool
+
+❌ Sticking with the initial model when deeper insight is available.
+
+> Be willing to refactor aggressively as understanding grows.
+
+## Practical Guidance
+
+### When Starting a Feature
+
+1. **What's the simplest thing that could work?**
+2. **What risks need to be addressed?**
+3. **What can we learn by building?**
+
+### When the Model Feels Wrong
+
+1. **Listen to the code** - Complexity smells indicate model problems
+2. **Check the language** - Are terms being used consistently?
+3. **Look for hidden concepts** - Is there a missing aggregate or value object?
+4. **Consider splitting** - Should this be multiple bounded contexts?
+
+### When to Refactor Aggressively
+
+- Ubiquitous language has diverged from the code
+- New business scenarios don't fit the current model
+- Transaction boundaries feel forced
+- Invariants are becoming complex
+
+## AI Usage Guide - How to Apply This Skill
+
+### When to Activate This Skill
+
+**Trigger this skill BEFORE writing code when:**
+
+- User mentions starting a new feature, epic, or user story
+- User says something like "I need to build..." or "How should I approach..."
+- There's uncertainty about domain concepts, boundaries, or requirements
+- Current model feels wrong or is getting complex
+- Planning an iteration or sprint
+
+**Do NOT use this skill when:**
+
+- User has a clear, specific coding task ("fix this bug", "add this method")
+- The code change is mechanical (refactoring, dependency updates)
+- Working within an established, well-understood domain
+
+### AI Role - The Facilitator, Not the Coder
+
+Your job is to **guide the user through analysis**, not to write code. Ask questions. Challenge assumptions. Help them think through the domain before committing to implementation.
+
+### The Planning Conversation Flow
+
+#### Phase 1: Establish Context (Questions to Ask)
+
+**If starting completely new:**
+
+- "What business problem are we solving?"
+- "Who are the users/actors involved?"
+- "What's the simplest scenario that demonstrates value?"
+- "What are the biggest unknowns or risks?"
+
+**If extending existing code:**
+
+- "What new behavior are we adding?"
+- "Does this fit the current model, or is it stretching?"
+- "Are we discovering new language, or reusing existing terms?"
+
+#### Phase 2: Identify the Walking Skeleton
+
+Guide the user to identify the thinnest possible vertical slice:
+
+- "What's the minimum that demonstrates end-to-end value?"
+- "Can we fake the complex parts initially?"
+- "What would we show in a demo?"
+
+**Rule:** If it can't be demonstrated, it's too big. Break it down.
+
+#### Phase 3: Risk Assessment
+
+Ask about risks that should drive the iteration:
+
+- "What technical pieces are uncertain?"
+- "What domain concepts are we fuzzy on?"
+- "What integrations or dependencies worry us?"
+
+**Priority:** Highest risk first, even if lower business value.
+
+#### Phase 4: Define the First Iteration Goal
+
+Before any code, establish:
+
+- "What's the specific goal for this iteration?"
+- "What will we have working by the end?"
+- "What are we explicitly NOT doing yet?"
+
+**Document this.** Create a simple statement: _"This iteration will [goal], demonstrating [scenario], while deferring [out-of-scope items]."_
+
+#### Phase 5: Ubiquitous Language Check
+
+Before coding, clarify language:
+
+- "What are we calling this concept?"
+- "Are we using terms consistently with the existing codebase?"
+- "Should we rename existing concepts to match new understanding?"
+
+**If language is unclear, the model is unclear.** Do not proceed.
+
+### When to Transition to Coding
+
+**Signal it's time to code:**
+
+1. Walking skeleton is defined and agreed upon
+2. Ubiquitous language is documented
+3. Out-of-scope items are explicitly listed
+4. User says "let's build this" or similar
+
+**Transition phrase:**
+
+> "Okay, let's build the walking skeleton for [goal]. I'll start with [first test/scenario]."
+
+### During Development - Stay Alert for Whirlpool Moments
+
+As you write code together, watch for signals that the model needs refinement:
+
+**If the user says:**
+
+- "This feels complicated" → Suggest: "Is there a missing concept? Should we refactor?"
+- "Actually, we also need to..." → Suggest: "Is this in scope for this iteration?"
+- "Hmm, that's not quite right" → Stop. Ask: "What did we get wrong about the domain?"
+
+**If the code shows:**
+
+- Complex conditionals → "Is there a missing aggregate or value object?"
+- Many null checks → "Should this be optional? Is there a missing concept?"
+- Comments explaining business rules → "Should this be explicit in the model?"
+
+### Anti-Pattern: AI Jumping to Code
+
+❌ **Wrong:**
+
+> User: "I need to handle order fulfillment"
+> AI: "Here's the OrderFulfillmentService with methods..."
+
+✅ **Right:**
+
+> User: "I need to handle order fulfillment"
+> AI: "Let's understand this before coding. What's the simplest fulfillment scenario? Who are the actors? What does 'fulfilled' mean in your domain?"
+
+### Integration with Other Skills
+
+- **use-case-creator** - Use cases evolve; update them as understanding grows
+- **testing** - Tests capture and protect domain understanding
+- **domain-driven-design** (if available) - Deep model refinement
+- **general-programming** - Refactoring skills support iteration
+
+---
+
+SPDX-FileCopyrightText: Copyright © 2026 Caleb Cushing
+
+SPDX-License-Identifier: CC-BY-NC-SA-4.0

--- a/skills/java/SKILL.md
+++ b/skills/java/SKILL.md
@@ -102,6 +102,50 @@ record Bar(String foo) {
 }
 ```
 
+## Use What's Already On The Classpath
+
+**Before writing any code, check if the functionality already exists in your dependencies.**
+
+If Guava's `Strings`, Apache Commons, or the JDK already has it → **use it**. Period.
+
+```java
+// BAD - even though it's "just" one line
+if (str == null) {
+    throw new NullPointerException("str must not be null");
+}
+
+// GOOD - it's already there, use it
+Objects.requireNonNull(str);
+```
+
+### The Rule Is Simple
+
+| Is it in your deps? | Action                          |
+| ------------------- | ------------------------------- |
+| Yes                 | Use it, no matter how "trivial" |
+| No                  | Then consider writing it        |
+
+### Check First
+
+Use the **javadocs MCP server** to search available classes before implementing:
+
+- `Strings` (Guava or Commons Lang3)
+- `Preconditions` / `Validate` (Guava / Commons Lang3)
+- `ObjectUtils` / `Objects` (Commons Lang3 / JDK)
+- `CollectionUtils` / `Iterables` / `Streams`
+
+### Benefits
+
+- **Zero additional dependencies** - it's already there!
+- **Less code to maintain** - delete your custom version
+- **Standard behavior** - what other developers expect
+- **Battle-tested** - edge cases already handled
+
+### Only Write Your Own When...
+
+- The functionality truly doesn't exist in any on-classpath library
+- You need behavior that's fundamentally different from available options
+
 ---
 
 SPDX-FileCopyrightText: Copyright © 2026 Caleb Cushing


### PR DESCRIPTION
Adds guidance to use existing library code before writing custom
implementations, and introduces iterative development principles
combining
Craig Larman RUP with Eric Evans whirlpool design.

Changes:
- Add javadocs MCP server configuration for Java API lookups
- Add Rule 6 to general-programming: Use Libraries When Available
- Add detailed Java skill section on using classpath libraries
- Include javadocs MCP as the tool for checking available classes
- Add iterative-development skill with:
  - Short timeboxed iterations (2-6 weeks)
  - Risk-driven development
  - Whirlpool design and refactoring toward deeper insight
  - Anti-patterns and practical guidance

---------

Co-authored-by: Kimi <kimi@moonshot.localhost>