### PR TITLE
ci: add renovate configuration and pre-commit workflow

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: Copyright © 2024-2026 Caleb Cushing
+//
+// SPDX-License-Identifier: CC0-1.0
+
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: ["config:recommended"],
+  dependencyDashboard: true,
+  timezone: "UTC",
+  platformAutomerge: true,
+  automergeStrategy: "squash",
+  // Rebase whenever PR falls behind base branch to keep them mergeable
+  rebaseWhen: "behind-base-branch",
+  // Subtrees are excluded - updates should be pulled via git subtree pull, not Renovate
+  // Squash merges break subtree history
+  ignorePaths: [".share/**", ".agents/**"],
+  // Remove the 'controls' section from PR body to avoid config noise in squash commits
+  prBodyTemplate: "{{{header}}}{{{table}}}{{{notes}}}{{{changelogs}}}{{{footer}}}",
+  hostRules: [
+    {
+      hostType: "maven",
+      matchHost: "https://maven.pkg.github.com",
+    },
+  ],
+  packageRules: [
+    {
+      matchManagers: ["maven"],
+      matchUpdateTypes: ["major", "minor", "patch"],
+      automerge: true,
+    },
+    {
+      // Python deps via uv: Run daily at 03:00 UTC (after update-java)
+      schedule: ["* 3 * * *"],
+      matchManagers: ["pep621"],
+      automerge: true,
+    },
+    {
+      matchManagers: ["pyenv"],
+      automerge: true,
+    },
+    {
+      matchManagers: ["github-actions"],
+      automerge: true,
+    },
+    {
+      // Pin xenoterracide org actions to commit SHAs for build reproducibility
+      // Only these get digest pins; other actions get normal version tag updates
+      matchManagers: ["github-actions"],
+      matchDepNames: ["xenoterracide/**"],
+      automerge: true,
+      pinDigests: true,
+    },
+    {
+      // Run every Wednesday
+      // Window: 04:00 UTC hour on Wednesday (Renovate cron uses '*' for minutes)
+      schedule: ["* 4 * * 3"],
+      matchManagers: ["npm", "asdf"],
+      groupName: "devDependencies",
+      matchUpdateTypes: ["minor", "patch", "pin"],
+      automerge: true,
+    },
+  ],
+}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright © 2024-2026 Caleb Cushing
+#
+# SPDX-License-Identifier: MIT
+
+name: pre-commit
+on: push
+permissions:
+  contents: read
+jobs:
+  license:
+    uses: xenoterracide/github/.github/workflows/license.yml@aa7403907abe7ccc7bcdbbc99445e0e8f9673452 # develop
+  prettier:
+    uses: xenoterracide/github/.github/workflows/prettier.yml@aa7403907abe7ccc7bcdbbc99445e0e8f9673452 # develop


### PR DESCRIPTION
Add Renovate configuration for automated dependency updates with:
- Recommended config as base with dependency dashboard enabled
- Platform automerge with squash strategy
- Scheduled updates for Python (daily 03:00 UTC) and npm/asdf (Wednesdays 04:00 UTC)
- Maven updates automerged for all types
- GitHub Actions with digest pinning for xenoterracide org actions
- Excluded paths for subtrees (.share/**, .agents/**)

Add pre-commit workflow with license and prettier checks.