### PR TITLE
ci: add build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright © 2024-2026 Caleb Cushing
+#
+# SPDX-License-Identifier: MIT
+
+name: build
+on:
+  push:
+    branches: ["**"]
+    tags: ["v*"]
+  workflow_call:
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      actions: write
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - &java
+        uses: actions/setup-java@v5.2.0
+        with:
+          distribution: temurin
+          java-version: 25
+          cache: maven
+      - run: ./mvnw verify --batch-mode --fail-at-end
+        env:
+          GH_USERNAME: ${{ github.actor }}
+          GH_TOKEN: ${{ github.token }}
+
+  full:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - *java
+      - run: ./mvnw clean verify --batch-mode --fail-at-end
+        env:
+          GH_USERNAME: ${{ github.actor }}
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Add GitHub Actions workflow for building the project.

The workflow runs on:
- All branch pushes
- Version tags (v*)
- Workflow calls from other workflows

Includes two jobs:
- build: Standard Maven verify with caching
- full: Clean build with Maven verify

Both jobs use:
- Ubuntu 24.04 runner
- Temurin JDK 25
- 5 minute timeout
- GitHub authentication for Maven